### PR TITLE
Delete example jupyter-js-ui dependency

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -2,8 +2,7 @@
   "private": true,
   "name": "jupyter-js-plugins-example",
   "dependencies": {
-    "jupyter-js-plugins": "file:..",
-    "jupyter-js-ui": "^0.5.1"
+    "jupyter-js-plugins": "file:.."
   },
   "scripts": {
     "build": "webpack --config webpack.conf.js",


### PR DESCRIPTION
This conflicts with the jupyter-js-plugin's dependency, and is not needed.
