### PR TITLE
Make tabs wider and an integer multiple of the height

### DIFF
--- a/src/default-theme/index.css
+++ b/src/default-theme/index.css
@@ -184,7 +184,7 @@ body {
 
 
 .p-TabBar-tab {
-  flex-basis: 124px;
+  flex-basis: 144px;
   min-height: 23px;
   max-height: 23px;
   min-width: 35px;


### PR DESCRIPTION
Right now tabs are 24px high and 124px wide. I am finding that that width is a tad small for many file names. Also, the width should ideally be an integer multiple of the height. Going up to a width of 144 (5*24) solves both of these problems.

Here is what it looks like:

<img width="503" alt="screen shot 2016-03-31 at 3 44 12 pm" src="https://cloud.githubusercontent.com/assets/27600/14193224/e3e1f63a-f757-11e5-9a7b-770f43f1ec47.png">
