### PR TITLE
Force a single phosphor-widget

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -3,7 +3,8 @@
   "name": "jupyter-js-plugins-example",
   "dependencies": {
     "es6-promise": "^3.1.2",
-    "jupyter-js-plugins": "file:.."
+    "jupyter-js-plugins": "file:..",
+    "phosphor-widget": "^1.0.0-rc.1"
   },
   "scripts": {
     "build": "webpack --config webpack.conf.js",

--- a/example/package.json
+++ b/example/package.json
@@ -3,8 +3,7 @@
   "name": "jupyter-js-plugins-example",
   "dependencies": {
     "es6-promise": "^3.1.2",
-    "jupyter-js-plugins": "file:..",
-    "phosphor-widget": "^1.0.0-rc.1"
+    "jupyter-js-plugins": "file:.."
   },
   "scripts": {
     "build": "webpack --config webpack.conf.js",

--- a/example/webpack.conf.js
+++ b/example/webpack.conf.js
@@ -23,7 +23,7 @@ module.exports = {
   },
   resolve: {
     alias: {
-      'phosphor-widget': path.resolve('./node_modules/phosphor-widget'),
+      'phosphor-widget': path.resolve('../node_modules/phosphor-widget'),
    },
 },
 

--- a/example/webpack.conf.js
+++ b/example/webpack.conf.js
@@ -1,4 +1,4 @@
-
+var path = require('path');
 module.exports = {
   entry: './index.js',
   output: {
@@ -20,5 +20,11 @@ module.exports = {
       // Handle image
       { test: /\.(jpg|png|gif|svg)$/, loader: "file" },
     ]
-  }
+  },
+  resolve: {
+    alias: {
+      'phosphor-widget': path.resolve('./node_modules/phosphor-widget'),
+   },
+},
+
 }


### PR DESCRIPTION
This prevents a dedupe error on older versions of `npm` that did not allow drag-drop to work.
