### PR TITLE
Script cleanup

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -4,15 +4,18 @@
   "dependencies": {
     "es6-promise": "^3.1.2",
     "jupyter-js-plugins": "file:..",
-    "phosphide": "^0.9.4"
+    "phosphide": "^0.9.4",
+    "webpack": "^1.13.1"
   },
   "scripts": {
     "build": "webpack --config webpack.conf.js",
     "clean": "rimraf build && rimraf node_modules",
     "postinstall": "npm dedupe",
-    "update": "rimraf node_modules/jupyter-js-plugins && npm install"
+    "update": "rimraf node_modules/jupyter-js-plugins && npm install",
+    "watch": "watch 'npm run update && npm run build' ../src src --wait 10"
   },
   "devDependencies": {
-    "rimraf": "^2.5.2"
+    "rimraf": "^2.5.2",
+    "watch": "^0.18.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "test:firefox": "karma start --browsers=Firefox test/karma.conf.js",
     "test:ie": "karma start --browsers=IE test/karma.conf.js",
     "test:debug": "karma start --browsers=Chrome --singleRun=false --debug=true test/karma.conf.js",
-    "test": "npm run build test && npm run test:firefox",
+    "test": "npm run build:test && npm run test:firefox",
     "watch": "watch 'npm run build' src --wait 10",
     "watch:test": "watch 'npm run build && npm test' src src/test --wait 10"
   },

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "build:example": "cd example && npm run update && npm run build",
     "build:src": "tsc --project src && node scripts/copyfiles.js",
     "build:test": "tsc --project test/src && webpack --config test/webpack.conf.js",
-    "build": "npm run build:src && npm run build:test",
+    "build": "npm run build:src",
     "docs": "typedoc --mode file --module commonjs --excludeNotExported --target es5 --moduleResolution node --out docs/ src",
     "postinstall": "npm dedupe",
     "prepublish": "npm run build",
@@ -63,9 +63,9 @@
     "test:firefox": "karma start --browsers=Firefox test/karma.conf.js",
     "test:ie": "karma start --browsers=IE test/karma.conf.js",
     "test:debug": "karma start --browsers=Chrome --singleRun=false --debug=true test/karma.conf.js",
-    "test": "npm run test:firefox",
-    "watch:example": "watch 'npm run build && npm run build:example' src --wait 10",
-    "watch": "watch 'npm run build' src"
+    "test": "npm run build test && npm run test:firefox",
+    "watch": "watch 'npm run build' src --wait 10",
+    "watch:test": "watch 'npm run build && npm test' src src/test --wait 10"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "postinstall": "npm dedupe",
     "prepublish": "npm run build",
     "test:chrome": "karma start --browsers=Chrome test/karma.conf.js",
-    "test:coverage": "webpack --config test/webpack-cov.conf.js && karma start test/karma-cov.conf.js",
+    "test:coverage": "npm run build:test && webpack --config test/webpack-cov.conf.js && karma start test/karma-cov.conf.js",
     "test:firefox": "karma start --browsers=Firefox test/karma.conf.js",
     "test:ie": "karma start --browsers=IE test/karma.conf.js",
     "test:debug": "karma start --browsers=Chrome --singleRun=false --debug=true test/karma.conf.js",

--- a/test/webpack-cov.conf.js
+++ b/test/webpack-cov.conf.js
@@ -3,7 +3,9 @@ var path = require('path');
 module.exports = {
   entry: './test/build/index.js',
   output: {
-    filename: './test/build/coverage.js'
+    path: __dirname + "/build",
+    filename: "coverage.js",
+    publicPath: "./build/"
   },
   bail: true,
   module: {

--- a/test/webpack.conf.js
+++ b/test/webpack.conf.js
@@ -3,7 +3,9 @@ var path = require('path');
 module.exports = {
   entry: './test/build/index.js',
   output: {
-    filename: './test/build/bundle.js'
+    path: __dirname + "/build",
+    filename: "bundle.js",
+    publicPath: "./build/"
   },
   bail: true,
   module: {


### PR DESCRIPTION
- Make the node scripts more modular.
- Make the example more self-contained.
- Add public path handling to the tests.
